### PR TITLE
BUGFIX: exit message being lost in read() operation in board_action()

### DIFF
--- a/Code/src/main.py
+++ b/Code/src/main.py
@@ -93,6 +93,7 @@ def board_action(board, controller, pub_sub_fct, biosignal=None):
         # TODO: Move this block of code under Message.PAUSE
         poll_board_for_messages(board, flush)
     elif message is Message.EXIT:
+        controller.send(Message.EXIT)
         return
 
     if recognized == False:


### PR DESCRIPTION
In main.py, board_action() actually **reads** messages (and therefore dequeues them from the controller). However, board_action() didn't handle Message.EXIT messages (and was handled by execute_board()). This means that if execute_board() received a message, delegated it to board_action(), and an EXIT message came in while board_action is about to start, then the EXIT message would be read (and dequeued) and lost.

**RESOLUTION**
board_action() resolved EXIT messages by calling safe_exit()