### PR TITLE
Added escapes for quotations in echo

### DIFF
--- a/Code/src/setup.sh
+++ b/Code/src/setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 pip3 install -r requirements.txt
-sudo bash -c 'echo KERNEL=="ttyUSB[0-9]*",NAME="tts/USB%n",SYMLINK+="%k",GROUP="uucp",MODE="0666" >> /etc/udev/rules.d/50-ttyusb.rules'
+sudo bash -c 'echo KERNEL==\"ttyUSB[0-9]*\",NAME=\"tts/USB%n\",SYMLINK+=\"%k\",GROUP=\"uucp\",MODE=\"0666\" >> /etc/udev/rules.d/50-ttyusb.rules'
 cd openbci_board
 python3 setup.py build_ext --inplace
 cd ..


### PR DESCRIPTION
Because I didn't escape the double quotations, echo doesn't write the correct output (with quotations) to the rules file.