### PR TITLE
Muse server

### DIFF
--- a/Code/src/gui/muse_2014_refactor/muse2014_lsl.py
+++ b/Code/src/gui/muse_2014_refactor/muse2014_lsl.py
@@ -1,53 +1,77 @@
 """This script receives raw EEG data from the muse and pushes it to an lsl outlet
+Useful as a test script.
 Adapted from:
     muse-lsl: https://github.com/alexandrebarachant/muse-lsl.git
     beats-muse: https://github.com/Oishe/beats-muse
 """
-from server import *
+import server
 import time
 from pylsl import StreamInfo, StreamOutlet
-
-PORT = '1234'
-info = StreamInfo('Muse', 'EEG', 4, 220, 'float32',
-                  'MuseName')
-
-info.desc().append_child_value("manufacturer", "Muse")
-channels = info.desc().append_child("channels")
-
-for c in ['TP9-l_ear', 'FP1-l_forehead', 'FP2-r_forehead', 'TP10-r_ear']:
-    channels.append_child("channel") \
-        .append_child_value("label", c) \
-        .append_child_value("unit", "microvolts") \
-        .append_child_value("type", "EEG")
-# specify info, chunk size (each push yields one chunk), and maximum buffered data
-outlet = StreamOutlet(info, 1, 360)
+import stream_rt as st
+import analysis_rt as an
+import markers_test
 
 
-def process(data, timestamp, index):
-    outlet.push_sample(data, timestamp)
+def main():
+    PORT = '1234'
+    info = StreamInfo('Muse', 'EEG', 4, 220, 'float32',
+                      'MuseName')
 
-    # test for response
-    if index % 220 == 0:
-        print('New Second! @', index, timestamp)
+    info.desc().append_child_value("manufacturer", "Muse")
+    channels = info.desc().append_child("channels")
 
+    for c in ['TP9-l_ear', 'FP1-l_forehead', 'FP2-r_forehead', 'TP10-r_ear']:
+        channels.append_child("channel") \
+            .append_child_value("label", c) \
+            .append_child_value("unit", "microvolts") \
+            .append_child_value("type", "EEG")
+    # specify info, chunk size (each push yields one chunk), and maximum buffered data
+    outlet = StreamOutlet(info, 1, 360)
+    if outlet:
+        print('EEG outlet created')
 
-# connect to the server
-try:
-    muse_server = PylibloServer(PORT, process)
-except ServerError:
-    muse_server = False
-
-if muse_server:
-    muse_server.start()
-
-while 1:
+    # connect to the server
     try:
-        time.sleep(1)
-    except:
-        break
+        muse_server = server.PylibloServer(PORT, server.process, outlet)
+    except server.ServerError:
+        raise ValueError('Cannot create PylibloServer Object')
+    if muse_server:
+        muse_server.connect()
 
-if muse_server:
+    # establish test marker stream; for test purposes only
+    outlet = markers_test.test_marker_stream()
+    print('marker stream started')
+
+    # connect to inlets
+    # Create MuseEEGStream object
+    eeg_stream = st.MuseEEGStream()
+
+    # Create Marker Stream object
+    marker_stream = st.MarkerStream()
+
+    # ensure streams are streaming data before accessing (there should be a better way to do this)
+    time.sleep(3)
+
+    # start marker test trial
+    markers_test.start_marker_stream(outlet)
+    # time for marker object to collect data
+    time.sleep(3.4)
+    # (When trial END signal arrives) make an epoch of the last 12 flashes and 1000 ms after
+    rt_filter = an.RTAnalysis(marker_stream, eeg_stream, data_duration=3.6)
+    rt_filter.start()
+
+    while 1:
+        try:
+            time.sleep(1)
+        except:
+            break
+
     muse_server.stop()
+
+
+if __name__ == '__main__':
+    main()
+
 
 
 

--- a/Code/src/gui/muse_2014_refactor/server.py
+++ b/Code/src/gui/muse_2014_refactor/server.py
@@ -1,12 +1,17 @@
 """Contains server that holds Pyliblo communication"""
 from liblo import *
 from pylsl import local_clock
+import threading
+
+
+def process(data, timestamp, outlet):
+    outlet.push_sample(data, timestamp)
 
 
 class PylibloServer(ServerThread):
     """class for 2014 muse hardware"""
 
-    def __init__(self, port=1234, callback=None):
+    def __init__(self, port=1234, callback=None, outlet=None):
         """Initialize"""
         ServerThread.__init__(self, port)
         # connection start time (needed for timestamping)
@@ -17,8 +22,27 @@ class PylibloServer(ServerThread):
         self.time_index = 0
         # callback function for lsl data push
         self.callback = callback
-
+        # lsl outlet to push data to
+        self.outlet = outlet
         # When new values are sent data is updated automatically
+        self._active = False
+        self._kill_signal = threading.Event()
+
+    def __del__(self):
+        # Break out of the loop of data collection.
+        self._kill_signal.set()
+
+    def connect(self):
+        if self._active:
+            raise RuntimeError("Stream already active.")
+        else:
+            # create thread to run pyliblo server on
+            self._thread = threading.Thread(target=self.start(), name='Muse-connection')
+            self._thread.daemon = True
+            self._thread.start()
+            self._active = True
+            print('Connected to Muse!')
+        return
 
     @make_method('/muse/eeg', 'ffff')
     def eeg_callback(self, path, args):
@@ -29,5 +53,5 @@ class PylibloServer(ServerThread):
         - calculate timestamp by multiplying index by frequency multiplier
         """
         timestamp = self.time_index * self.freq_mult + self.start_time
-        self.callback(args, timestamp, self.time_index)
+        self.callback(args, timestamp, self.time_index, self.outlet)
         self.time_index += 1


### PR DESCRIPTION
Move all muse-server functions to server.py. These functions allow the muse to publish eeg data on lsl. Currently runs on python 2.7, but in process of getting requirements for python 3.6 (liblo is causing problems). Also convert muse2014_lsl.py to a test/demonstration script. 